### PR TITLE
CI 리펙토링

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+
+    - name: Checkout code
+      uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -18,14 +20,15 @@ jobs:
       with:
         java-version: 1.8
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-
-    - name: Build with Gradle
+    - name: Copy secret
       env:
         OCCUPY_SECRET: ${{ secrets.OCCUPY_SECRET }}
         OCCUPY_SECRET_DIR: src/main/resources
         OCCUPY_SECRET_DIR_FILE_NAME: secret.yml
-      run: |
-        echo $OCCUPY_SECRET | base64 --decode > $OCCUPY_SECRET_DIR/$OCCUPY_SECRET_DIR_FILE_NAME
-        ./gradlew build
+      run: echo $OCCUPY_SECRET | base64 --decode > $OCCUPY_SECRET_DIR/$OCCUPY_SECRET_DIR_FILE_NAME
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew build


### PR DESCRIPTION
CI 코드에 checkout 역할을 명시하기 위한 name 속성을 추가한다.

step별로 하나의 책임만 가지도록 하기 위해 copy secret 파일을
복사하는 step과 gradle build step을 분리한다.

issue items: #11