### PR TITLE
CI 파이프라인 명 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: build
+name: CI
 
 on:
   pull_request:


### PR DESCRIPTION
파이프라인명이 build로 되어 있는데 정확히
파이프라인이 하는 명을 명시하고 있지 않는 것 같아
파이프라인명을 CI로 변경한다.

As-Is: build
To-Be: CI

issue items: #19
close: #19