### PR TITLE
카카오 스킬 요청 오류 수정

### DIFF
--- a/src/main/kotlin/com/kh/api/request/DetailParam.kt
+++ b/src/main/kotlin/com/kh/api/request/DetailParam.kt
@@ -2,6 +2,5 @@ package com.kh.api.request
 
 data class DetailParam(
         val origin: String,
-        val value: String,
-        val groupName: String
+        val value: String
 )

--- a/src/test/kotlin/com/kh/util/RequestBodyCreator.kt
+++ b/src/test/kotlin/com/kh/util/RequestBodyCreator.kt
@@ -129,14 +129,32 @@ class RequestBodyCreator(private val korail: Korail) {
                   },
                   "action": {
                     "name": "g0xxzoae15",
-                    "clientExtra": null,
                     "params": {
                       "departure-date": "$departureDate",
                       "departure-time": "$departureTime",
                       "departure-station": "$departureStation",
                       "destination-station": "$destinationStation"
                     },
-                    "id": "krcu052b90c6angense4fxgy"
+                    "id": "krcu052b90c6angense4fxgy",
+                    "detailParams": {
+                      "departure-date": {
+                        "origin": "20200302",
+                        "value": "20200302"
+                      },
+                      "departure-time": {
+                        "origin": "070000",
+                        "value": "070000"
+                      },
+                      "departure-station": {
+                        "origin": "서울",
+                        "value": "서울"
+                      },
+                      "destination-station": {
+                        "origin": "부산",
+                        "value": "부산"
+                      }
+                    },
+                    "clientExtra": {}
                   }
                 }
             """.trimIndent()


### PR DESCRIPTION
카카오 스킬 전송요청 양식이 변경되어
서버에서 400 Bad-Request 오류를 반환한다.

원인은 요청 메시지 중 `groupName`속성 값이 제거되어
전송되어 JSON을 파싱할때 오류가 발생하기 때문이다.

Payload에서 해당 속석을 제거하여 요청응답이 정상동작하도록
오류를 수정한다.

issue items: #38

close #38 