### PR TITLE
FixtureExtension 클래스 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ val jvmTargetVersion: String by project
 val projectVersion: String by project
 val snakeyamlVersion: String by project
 val mockitoInlineVersion: String by project
+val fixtureVersion: String by project
 
 plugins {
 	id("org.springframework.boot")
@@ -18,6 +19,7 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
 	mavenCentral()
+	jcenter()
 }
 
 dependencies {
@@ -32,6 +34,7 @@ dependencies {
 	}
 	testImplementation("io.projectreactor:reactor-test")
 	testRuntimeOnly("org.mockito:mockito-inline:$mockitoInlineVersion")
+	testImplementation("com.appmattus.fixture:fixture:$fixtureVersion")
 }
 
 tasks.withType<KotlinCompile> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ springBootVersion=2.2.4.RELEASE
 springDependencyManagementVersion=1.0.9.RELEASE
 snakeyamlVersion=1.25
 mockitoInlineVersion=3.1.0
+fixtureVersion=0.7.1

--- a/src/test/kotlin/com/kh/testingHelper/FixtureExtension.kt
+++ b/src/test/kotlin/com/kh/testingHelper/FixtureExtension.kt
@@ -1,0 +1,21 @@
+package com.kh.testingHelper
+
+import com.appmattus.kotlinfixture.kotlinFixture
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
+
+class FixtureExtension : ParameterResolver {
+    override fun supportsParameter(
+            parameterContext: ParameterContext?,
+            extensionContext: ExtensionContext?): Boolean {
+        return true
+    }
+
+    override fun resolveParameter(
+            parameterContext: ParameterContext?,
+            extensionContext: ExtensionContext?): Any {
+        val type = parameterContext!!.parameter.type
+        return kotlinFixture().create(type)!!
+    }
+}


### PR DESCRIPTION
FixtureExtension 클래스를 추가한다.

해당 클래스는 Kotlin Fixture를 Test 함수별로 손쉽게
생성하기 위해서 Jupiter의 ExtendWith의 매개변수로 사용한다.

참고:
https://github.com/junit-team/junit5-samples/blob/master/junit5-jupiter-extensions/src/main/java/com/example/random/RandomParametersExtension.java

issue items: #45
close: #45 