### PR TITLE
MockWebServer 의존성 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ val projectVersion: String by project
 val snakeyamlVersion: String by project
 val mockitoInlineVersion: String by project
 val fixtureVersion: String by project
+val mockwebserverVersion: String by project
 
 plugins {
 	id("org.springframework.boot")
@@ -35,6 +36,8 @@ dependencies {
 	testImplementation("io.projectreactor:reactor-test")
 	testRuntimeOnly("org.mockito:mockito-inline:$mockitoInlineVersion")
 	testImplementation("com.appmattus.fixture:fixture:$fixtureVersion")
+	testImplementation("com.squareup.okhttp3:okhttp:$mockwebserverVersion")
+	testImplementation("com.squareup.okhttp3:mockwebserver:$mockwebserverVersion")
 }
 
 tasks.withType<KotlinCompile> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ springDependencyManagementVersion=1.0.9.RELEASE
 snakeyamlVersion=1.25
 mockitoInlineVersion=3.1.0
 fixtureVersion=0.7.1
+mockwebserverVersion=4.4.0


### PR DESCRIPTION
MockWebServer는 Mokito를 이용한 테스팅이 아닌
Http/Https 요청에 대한 가상의 응답을 제공하는
서버를 통해 실제로 통신하는 것처럼 테스트를
하기 위한 도구이다.

Spring Team에서는 Mokito를 이용한 테스팅이 아닌
MockWebServer를 통한 테스팅을 권장한다.

참고:
https://github.com/square/okhttp/tree/master/mockwebserver
https://www.baeldung.com/spring-mocking-webclient

issue items: #51
close: #51