### PR TITLE
TicketBox 인터페이스 함수 정의 변경

### DIFF
--- a/src/main/kotlin/com/kh/occupying/TicketBox.kt
+++ b/src/main/kotlin/com/kh/occupying/TicketBox.kt
@@ -1,6 +1,8 @@
 package com.kh.occupying
 
+import reactor.core.publisher.Mono
+
 interface TicketBox {
-    fun <T> find(param: T): ItemDto<Ticket>
-    fun reserve(ticket: Ticket)
+    fun <T> find(param: T): Mono<ItemDto<Ticket>>
+    fun reserve(ticket: Ticket): Mono<Unit>
 }


### PR DESCRIPTION
TicketBox에 정의된 `find`와 `reserve` 함수는
non-blocking 함수로 사용되어야 하므로
반환타입을 Mono<T>로 변경한다.

issue items: #47
close: #47