### PR TITLE
TargetApiProperties 인터페이스 추가

### DIFF
--- a/src/main/kotlin/com/kh/occupying/TargetApiProperties.kt
+++ b/src/main/kotlin/com/kh/occupying/TargetApiProperties.kt
@@ -1,0 +1,10 @@
+package com.kh.occupying
+
+interface TargetApiProperties {
+    fun getSchema(): String
+    fun getHost(): String
+    fun getPort(): Int
+    fun getFindPath(): String
+    fun getReservePath(): String
+    fun getLoginPath(): String
+}


### PR DESCRIPTION
TargetApiProperties 인터페이스를 추가한다.
해당 인터페이스는 TargetApi의 접속 경로 등
속성값들을 제공해주는 역할을 한다.

issue items: #48
close: #48