### PR TITLE
불필요한 junit4 의존성 제거

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,9 @@ dependencies {
 	testRuntimeOnly("org.mockito:mockito-inline:$mockitoInlineVersion")
 	testImplementation("com.appmattus.fixture:fixture:$fixtureVersion")
 	testImplementation("com.squareup.okhttp3:okhttp:$mockwebserverVersion")
-	testImplementation("com.squareup.okhttp3:mockwebserver:$mockwebserverVersion")
+	testImplementation("com.squareup.okhttp3:mockwebserver:$mockwebserverVersion") {
+		exclude("junit")
+	}
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
mockwebserver라이브러리에서 junit4 의존성을 포함하고 있다.
불필요하므로 juni4 의존성을 제거하는 코드를 추가한다.

issue items: #55
close: #55