### PR TITLE
Revert "불필요한 junit4 의존성 제거"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,9 +37,7 @@ dependencies {
 	testRuntimeOnly("org.mockito:mockito-inline:$mockitoInlineVersion")
 	testImplementation("com.appmattus.fixture:fixture:$fixtureVersion")
 	testImplementation("com.squareup.okhttp3:okhttp:$mockwebserverVersion")
-	testImplementation("com.squareup.okhttp3:mockwebserver:$mockwebserverVersion") {
-		exclude("junit")
-	}
+	testImplementation("com.squareup.okhttp3:mockwebserver:$mockwebserverVersion")
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
 테스팅 시 `MockWebServer` 클래스의 함수가 동작하려면 junit4 의존성이 필요해서
해당 PR을 Revert 한다.

issue items: #56 