### PR TITLE
KorailTargetApiProperties 생성

### DIFF
--- a/src/main/kotlin/com/kh/occupying/korail/KorailTargetApiProperties.kt
+++ b/src/main/kotlin/com/kh/occupying/korail/KorailTargetApiProperties.kt
@@ -1,0 +1,20 @@
+package com.kh.occupying.korail
+
+import com.kh.occupying.TargetApiProperties
+
+object KorailTargetApiProperties : TargetApiProperties {
+    private const val schema = "https"
+    private const val host = "smart.letskorail.com"
+    private const val port = 443
+    private const val contextPath = "/classes/com.korail.mobile."
+    private const val findPath = "seatMovie.ScheduleView"
+    private const val reservePath = "certification.TicketReservation"
+    private const val loginPath = "login.Login"
+
+    override fun getSchema() = schema
+    override fun getHost() = host
+    override fun getPort() = port
+    override fun getFindPath() = contextPath + findPath
+    override fun getReservePath() = contextPath + reservePath
+    override fun getLoginPath() = contextPath + loginPath
+}


### PR DESCRIPTION
KorailTargetApiProperties object를 생성한다.
KorailTargetApiProperties는 TargetApiProperties 인터페이스를 구현하며
Korail에서 제공하는 API의 접속정보 등을 담고 있다.

issue items: #61
close: #61 